### PR TITLE
Fixed error that would lead to an exception when receiving an empty string

### DIFF
--- a/Classes/HexColor.m
+++ b/Classes/HexColor.m
@@ -23,6 +23,10 @@
 
 + (HXColor *)colorWithHexString:(NSString *)hexString alpha:(CGFloat)alpha
 {
+    if (hexString.length == 0) {
+        return nil;
+    }
+    
     // Check for hash and add the missing hash
     if('#' != [hexString characterAtIndex:0])
     {


### PR DESCRIPTION
The case:

```objc
[HXColor colorWithHexString:@""];
```

would raise an exception. 

This commit places a 'safe-net' for `nil` or empty strings received as argument. 