### PR TITLE
Add prefix to category methods to prevent name collision.

### DIFF
--- a/Classes/HexColors.h
+++ b/Classes/HexColors.h
@@ -24,10 +24,10 @@
 
 @interface HXColor (HexColorAddition)
 
-+ (HXColor *)colorWithHexString:(NSString *)hexString;
-+ (HXColor *)colorWithHexString:(NSString *)hexString alpha:(CGFloat)alpha;
++ (HXColor *)hex_colorWithHexString:(NSString *)hexString;
++ (HXColor *)hex_colorWithHexString:(NSString *)hexString alpha:(CGFloat)alpha;
 
-+ (HXColor *)colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue;
-+ (HXColor *)colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue alpha:(CGFloat)alpha;
++ (HXColor *)hex_colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue;
++ (HXColor *)hex_colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue alpha:(CGFloat)alpha;
 
 @end

--- a/Classes/HexColors.m
+++ b/Classes/HexColors.m
@@ -33,7 +33,7 @@
         alpha = ((CGFloat) alpha_u) / 255.0;
     }
 
-    return [[self class] colorWithHexString:hexString alpha:alpha];
+    return [[self class] hex_colorWithHexString:hexString alpha:alpha];
 }
 
 + (HXColor *)hex_colorWithHexString:(NSString *)hexString alpha:(CGFloat)alpha
@@ -41,18 +41,18 @@
     if (hexString.length == 0) {
         return nil;
     }
-    
+
     // Check for hash and add the missing hash
     if('#' != [hexString characterAtIndex:0])
     {
         hexString = [NSString stringWithFormat:@"#%@", hexString];
     }
-    
+
     // check for string length
     if (7 != hexString.length && 4 != hexString.length) {
         NSString *defaultHex    = [NSString stringWithFormat:@"0xff"];
         unsigned defaultInt = [[self class] hexValueToUnsigned:defaultHex];
-        
+
         HXColor *color = [HXColor hex_colorWith8BitRed:defaultInt green:defaultInt blue:defaultInt alpha:1.0];
         return color;
     }
@@ -68,15 +68,15 @@
     
     NSString *blueHex   = [NSString stringWithFormat:@"0x%@", [hexString substringWithRange:NSMakeRange(5, 2)]];
     unsigned blueInt = [[self class] hexValueToUnsigned:blueHex];
-    
+
     HXColor *color = [HXColor hex_colorWith8BitRed:redInt green:greenInt blue:blueInt alpha:alpha];
-    
+
     return color;
 }
 
 + (HXColor *)hex_colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue
 {
-    return [[self class] colorWith8BitRed:red green:green blue:blue alpha:1.0];
+    return [[self class] hex_colorWith8BitRed:red green:green blue:blue alpha:1.0];
 }
 
 + (HXColor *)hex_colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue alpha:(CGFloat)alpha
@@ -87,7 +87,7 @@
 #else
     color = [HXColor colorWithCalibratedRed:(float)red/255 green:(float)green/255 blue:(float)blue/255 alpha:alpha];
 #endif
-    
+
     return color;
 }
 
@@ -101,17 +101,17 @@
                      [hexString characterAtIndex:3]];
         
     }
-    
+
     return hexString;
 }
 
 + (unsigned)hexValueToUnsigned:(NSString *)hexValue
 {
     unsigned value = 0;
-    
+
     NSScanner *hexValueScanner = [NSScanner scannerWithString:hexValue];
     [hexValueScanner scanHexInt:&value];
-    
+
     return value;
 }
 

--- a/Classes/HexColors.m
+++ b/Classes/HexColors.m
@@ -16,7 +16,7 @@
 
 @implementation HXColor (HexColorAddition)
 
-+ (HXColor *)colorWithHexString:(NSString *)hexString
++ (HXColor *)hex_colorWithHexString:(NSString *)hexString
 {
     // Check for hash and add the missing hash
     if('#' != [hexString characterAtIndex:0])
@@ -36,7 +36,7 @@
     return [[self class] colorWithHexString:hexString alpha:alpha];
 }
 
-+ (HXColor *)colorWithHexString:(NSString *)hexString alpha:(CGFloat)alpha
++ (HXColor *)hex_colorWithHexString:(NSString *)hexString alpha:(CGFloat)alpha
 {
     if (hexString.length == 0) {
         return nil;
@@ -53,7 +53,7 @@
         NSString *defaultHex    = [NSString stringWithFormat:@"0xff"];
         unsigned defaultInt = [[self class] hexValueToUnsigned:defaultHex];
         
-        HXColor *color = [HXColor colorWith8BitRed:defaultInt green:defaultInt blue:defaultInt alpha:1.0];
+        HXColor *color = [HXColor hex_colorWith8BitRed:defaultInt green:defaultInt blue:defaultInt alpha:1.0];
         return color;
     }
     
@@ -69,17 +69,17 @@
     NSString *blueHex   = [NSString stringWithFormat:@"0x%@", [hexString substringWithRange:NSMakeRange(5, 2)]];
     unsigned blueInt = [[self class] hexValueToUnsigned:blueHex];
     
-    HXColor *color = [HXColor colorWith8BitRed:redInt green:greenInt blue:blueInt alpha:alpha];
+    HXColor *color = [HXColor hex_colorWith8BitRed:redInt green:greenInt blue:blueInt alpha:alpha];
     
     return color;
 }
 
-+ (HXColor *)colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue
++ (HXColor *)hex_colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue
 {
     return [[self class] colorWith8BitRed:red green:green blue:blue alpha:1.0];
 }
 
-+ (HXColor *)colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue alpha:(CGFloat)alpha
++ (HXColor *)hex_colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue alpha:(CGFloat)alpha
 {
     HXColor *color = nil;
 #if (TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE)

--- a/Example/HexColor Examples/HexColorExampleViewController.m
+++ b/Example/HexColor Examples/HexColorExampleViewController.m
@@ -38,37 +38,37 @@
 
 - (IBAction)colorOne:(id)sender {
     [UIView animateWithDuration:0.3 animations:^{
-        self.backgroundView.backgroundColor = [UIColor colorWithHexString:@"#999999"];
+        self.backgroundView.backgroundColor = [UIColor hex_colorWithHexString:@"#999999"];
     }];
 }
 
 - (IBAction)colorTwo:(id)sender {
     [UIView animateWithDuration:0.3 animations:^{
-        self.backgroundView.backgroundColor = [UIColor colorWithHexString:@"#334455"];
+        self.backgroundView.backgroundColor = [UIColor hex_colorWithHexString:@"#334455"];
     }];
 }
 
 - (IBAction)colorThree:(id)sender {
     [UIView animateWithDuration:0.3 animations:^{
-        self.backgroundView.backgroundColor = [UIColor colorWithHexString:@"#ff0099"];
+        self.backgroundView.backgroundColor = [UIColor hex_colorWithHexString:@"#ff0099"];
     }];
 }
 
 - (IBAction)color333:(id)sender {
     [UIView animateWithDuration:0.3 animations:^{
-        self.backgroundView.backgroundColor = [UIColor colorWithHexString:@"333"];
+        self.backgroundView.backgroundColor = [UIColor hex_colorWithHexString:@"333"];
     }];
 }
 
 - (IBAction)color656:(id)sender {
     [UIView animateWithDuration:0.3 animations:^{
-        self.backgroundView.backgroundColor = [UIColor colorWithHexString:@"656"];
+        self.backgroundView.backgroundColor = [UIColor hex_colorWithHexString:@"656"];
     }];
 }
 
 - (IBAction)color295:(id)sender {
     [UIView animateWithDuration:0.3 animations:^{
-        self.backgroundView.backgroundColor = [UIColor colorWithHexString:@"295"];
+        self.backgroundView.backgroundColor = [UIColor hex_colorWithHexString:@"295"];
     }];
 }
 @end


### PR DESCRIPTION
Hello,

after using **HexColors** within our project, via **TSMessage** pod, I have discovered that the category methods are not prefixed. Which in turn led to name collision with similar category used by another pod.

As it turns out this was one of those sneaky bug's to discover :).

Method name that collided was:

	colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue
	
I think it is a good pratice to have prefix on categories.

And by the way thanks for all your work, this is one of those must have libraries.

