### PR TITLE
RGBA methods for hex strings

### DIFF
--- a/Classes/HexColors.h
+++ b/Classes/HexColors.h
@@ -32,7 +32,18 @@
  @param hexString NSString hex string for color generation
  @return UIColor / NSColor or nil
  */
-+ (nullable HXColor *)hx_colorWithHexString:(nonnull NSString *)hexString;
++ (nullable HXColor *)hx_colorWithHexString:(nonnull NSString *)hexString __attribute__ ((deprecated("Use '-hx_colorWithHexRGBAString' instead.")));
+
+/**
+ Creates a UIColor or NSColor from a HexString like #fff, #ffff, #ff00aa or #ff00aaee.
+ With complete support for short hand hex values, short hand with short alpha value, full
+ hex values and full hex values with alpha. To include alpha with the hex string append the values
+ at the end of the string.
+ 
+ @param hexString NSString hex string for color generation
+ @return UIColor / NSColor or nil
+ */
++ (nullable HXColor *)hx_colorWithHexRGBAString:(nonnull NSString *)hexString;
 
 /**
  Same implementation as hx_colorWithHexString but you can hand in a normal alpha value from 0 to 1
@@ -41,7 +52,16 @@
  @param alpha CGFloat from 0 to 1
  @return UIColor / NSColor or nil
  */
-+ (nullable HXColor *)hx_colorWithHexString:(nonnull NSString *)hexString alpha:(CGFloat)alpha;
++ (nullable HXColor *)hx_colorWithHexString:(nonnull NSString *)hexString alpha:(CGFloat)alpha __attribute__ ((deprecated("Use '-hx_colorWithHexRGBAString :alpha' instead.")));
+
+/**
+ Same implementation as hx_colorWithHexRGBAString but you can hand in a normal alpha value from 0 to 1
+ 
+ @param hexString NSString hex string for color generation
+ @param alpha CGFloat from 0 to 1
+ @return UIColor / NSColor or nil
+ */
++ (nullable HXColor *)hx_colorWithHexRGBAString:(nonnull NSString *)hexString alpha:(CGFloat)alpha;
 
 /**
  Don't like to devide by 255 to get a value between 0 to 1 for creating a color? This helps you create 

--- a/Classes/HexColors.m
+++ b/Classes/HexColors.m
@@ -21,6 +21,63 @@
     return [[self class] hx_colorWithHexString:hexString alpha:1.0];
 }
 
++ (HXColor *)hx_colorWithHexRGBAString:(NSString *)hexString
+{
+    return [[self class] hx_colorWithHexRGBAString:hexString alpha:1.0];
+}
+
++ (HXColor *)hx_colorWithHexRGBAString:(NSString *)hexString alpha:(CGFloat)alpha
+{
+    // We found an empty string, we are returning nothing
+    if (hexString.length == 0) {
+        return nil;
+    }
+    
+    // Check for hash and add the missing hash
+    if('#' != [hexString characterAtIndex:0]) {
+        hexString = [NSString stringWithFormat:@"#%@", hexString];
+    }
+    
+    // returning no object on wrong alpha values
+    NSArray *validHexStringLengths = @[@4, @5, @7, @9];
+    NSNumber *hexStringLengthNumber = [NSNumber numberWithUnsignedInteger:hexString.length];
+    if ([validHexStringLengths indexOfObject:hexStringLengthNumber] == NSNotFound) {
+        return nil;
+    }
+    
+    // if the hex string is 5 or 9 we are ignoring the alpha value and we are using the value from the hex string instead
+    CGFloat handedInAlpha = alpha;
+    if (5 == hexString.length || 9 == hexString.length) {
+        NSString *alphaHex;
+        if (5 == hexString.length) {
+            alphaHex = [hexString substringWithRange:NSMakeRange(4, 1)];
+        } else {
+            alphaHex = [hexString substringWithRange:NSMakeRange(7, 2)];
+        }
+        if (1 == alphaHex.length) alphaHex = [NSString stringWithFormat:@"%@%@", alphaHex, alphaHex];
+        //hexString = [NSString stringWithFormat:@"#%@", [hexString substringFromIndex:9 == hexString.length ? 7 : 3]];
+        hexString = [NSString stringWithFormat:@"#%@", [hexString substringWithRange:NSMakeRange(1, 9 == hexString.length ? 6 : 3)]];
+        unsigned alpha_u = [[self class] hx_hexValueToUnsigned:alphaHex];
+        handedInAlpha = ((CGFloat) alpha_u) / 255.0;
+    }
+    
+    // check for 3 character HexStrings
+    hexString = [hexString hx_hexStringTransformFromThreeCharacters];
+    
+    NSString *redHex    = [NSString stringWithFormat:@"0x%@", [hexString substringWithRange:NSMakeRange(1, 2)]];
+    unsigned redInt = [[self class] hx_hexValueToUnsigned:redHex];
+    
+    NSString *greenHex  = [NSString stringWithFormat:@"0x%@", [hexString substringWithRange:NSMakeRange(3, 2)]];
+    unsigned greenInt = [[self class] hx_hexValueToUnsigned:greenHex];
+    
+    NSString *blueHex   = [NSString stringWithFormat:@"0x%@", [hexString substringWithRange:NSMakeRange(5, 2)]];
+    unsigned blueInt = [[self class] hx_hexValueToUnsigned:blueHex];
+    
+    HXColor *color = [HXColor hx_colorWith8BitRed:redInt green:greenInt blue:blueInt alpha:handedInAlpha];
+    
+    return color;
+}
+
 + (HXColor *)hx_colorWithHexString:(NSString *)hexString alpha:(CGFloat)alpha
 {
     // We found an empty string, we are returning nothing

--- a/HexColorsTests/HexColorsTests.m
+++ b/HexColorsTests/HexColorsTests.m
@@ -27,14 +27,14 @@
 
 - (void)testEmptyHexString {
     
-    UIColor *nilColor = [UIColor hx_colorWithHexRGBAString:@""];
+    UIColor *nilColor = [UIColor hx_colorWithHexString:@""];
     
     NSAssert(nilColor == nil, @"nilColor is not nil");
 }
 
 - (void)testInvalidHexStringLength {
     
-    UIColor *falseColor = [UIColor hx_colorWithHexRGBAString:@"12345"];
+    UIColor *falseColor = [UIColor hx_colorWithHexString:@"12345"];
     
     NSAssert(falseColor == nil, @"String should not create a valid color");
 }
@@ -42,7 +42,7 @@
 - (void)testShortSyntaxWithHash {
     
     UIColor *whiteColor = [UIColor whiteColor];
-    UIColor *whiteHexColor = [UIColor hx_colorWithHexRGBAString:@"#fff"];
+    UIColor *whiteHexColor = [UIColor hx_colorWithHexString:@"#fff"];
     
     NSAssert(whiteColor != whiteHexColor, @"hexColor is not equal to the white color");
 }
@@ -50,7 +50,7 @@
 - (void)testShortSyntaxWithoutHash {
     
     UIColor *whiteColor = [UIColor whiteColor];
-    UIColor *whiteHexColor = [UIColor hx_colorWithHexRGBAString:@"fff"];
+    UIColor *whiteHexColor = [UIColor hx_colorWithHexString:@"fff"];
     
     NSAssert(whiteColor != whiteHexColor, @"hexColor is not equal to white color");
 }
@@ -58,7 +58,7 @@
 - (void)testShortSyntaxWithHashAndAlpha {
     
     UIColor *whiteColorAlpha = [UIColor colorWithWhite:1 alpha:0.533333];
-    UIColor *whiteHexColorAlpha = [UIColor hx_colorWithHexRGBAString:@"8fff"];
+    UIColor *whiteHexColorAlpha = [UIColor hx_colorWithHexString:@"8fff"];
     
     NSAssert(whiteColorAlpha != whiteHexColorAlpha, @"hexColor is not equal to white alpha hexColor");
 }

--- a/HexColorsTests/HexColorsTests.m
+++ b/HexColorsTests/HexColorsTests.m
@@ -27,14 +27,14 @@
 
 - (void)testEmptyHexString {
     
-    UIColor *nilColor = [UIColor hx_colorWithHexString:@""];
+    UIColor *nilColor = [UIColor hx_colorWithHexRGBAString:@""];
     
     NSAssert(nilColor == nil, @"nilColor is not nil");
 }
 
 - (void)testInvalidHexStringLength {
     
-    UIColor *falseColor = [UIColor hx_colorWithHexString:@"12345"];
+    UIColor *falseColor = [UIColor hx_colorWithHexRGBAString:@"12345"];
     
     NSAssert(falseColor == nil, @"String should not create a valid color");
 }
@@ -42,7 +42,7 @@
 - (void)testShortSyntaxWithHash {
     
     UIColor *whiteColor = [UIColor whiteColor];
-    UIColor *whiteHexColor = [UIColor hx_colorWithHexString:@"#fff"];
+    UIColor *whiteHexColor = [UIColor hx_colorWithHexRGBAString:@"#fff"];
     
     NSAssert(whiteColor != whiteHexColor, @"hexColor is not equal to the white color");
 }
@@ -50,7 +50,7 @@
 - (void)testShortSyntaxWithoutHash {
     
     UIColor *whiteColor = [UIColor whiteColor];
-    UIColor *whiteHexColor = [UIColor hx_colorWithHexString:@"fff"];
+    UIColor *whiteHexColor = [UIColor hx_colorWithHexRGBAString:@"fff"];
     
     NSAssert(whiteColor != whiteHexColor, @"hexColor is not equal to white color");
 }
@@ -58,7 +58,7 @@
 - (void)testShortSyntaxWithHashAndAlpha {
     
     UIColor *whiteColorAlpha = [UIColor colorWithWhite:1 alpha:0.533333];
-    UIColor *whiteHexColorAlpha = [UIColor hx_colorWithHexString:@"8fff"];
+    UIColor *whiteHexColorAlpha = [UIColor hx_colorWithHexRGBAString:@"8fff"];
     
     NSAssert(whiteColorAlpha != whiteHexColorAlpha, @"hexColor is not equal to white alpha hexColor");
 }

--- a/HexColorsTests/HexColorsTests.m
+++ b/HexColorsTests/HexColorsTests.m
@@ -53,6 +53,14 @@
     NSAssert(falseColor == nil, @"String should not create a valid color");
 }
 
+- (void)testLongRGBASyntaxWithHash {
+    
+    UIColor *whiteColor = [UIColor whiteColor];
+    UIColor *whiteHexColor = [UIColor hx_colorWithHexRGBAString:@"#ffffffff"];
+    
+    NSAssert(whiteColor != whiteHexColor, @"hexColor is not equal to the white color");
+}
+
 - (void)testShortSyntaxWithHash {
     
     UIColor *whiteColor = [UIColor whiteColor];

--- a/HexColorsTests/HexColorsTests.m
+++ b/HexColorsTests/HexColorsTests.m
@@ -32,9 +32,23 @@
     NSAssert(nilColor == nil, @"nilColor is not nil");
 }
 
+- (void)testEmptyHexStringRGBA {
+    
+    UIColor *nilColor = [UIColor hx_colorWithHexRGBAString:@""];
+    
+    NSAssert(nilColor == nil, @"nilColor is not nil");
+}
+
 - (void)testInvalidHexStringLength {
     
     UIColor *falseColor = [UIColor hx_colorWithHexString:@"12345"];
+    
+    NSAssert(falseColor == nil, @"String should not create a valid color");
+}
+
+- (void)testInvalidHexStringRGBSLength {
+    
+    UIColor *falseColor = [UIColor hx_colorWithHexRGBAString:@"12345"];
     
     NSAssert(falseColor == nil, @"String should not create a valid color");
 }
@@ -47,6 +61,14 @@
     NSAssert(whiteColor != whiteHexColor, @"hexColor is not equal to the white color");
 }
 
+- (void)testShortRGBASyntaxWithHash {
+    
+    UIColor *whiteColor = [UIColor whiteColor];
+    UIColor *whiteHexColor = [UIColor hx_colorWithHexRGBAString:@"#fff"];
+    
+    NSAssert(whiteColor != whiteHexColor, @"hexColor is not equal to the white color");
+}
+
 - (void)testShortSyntaxWithoutHash {
     
     UIColor *whiteColor = [UIColor whiteColor];
@@ -55,10 +77,26 @@
     NSAssert(whiteColor != whiteHexColor, @"hexColor is not equal to white color");
 }
 
+- (void)testShortRGBASyntaxWithoutHash {
+    
+    UIColor *whiteColor = [UIColor whiteColor];
+    UIColor *whiteHexColor = [UIColor hx_colorWithHexRGBAString:@"fff"];
+    
+    NSAssert(whiteColor != whiteHexColor, @"hexColor is not equal to white color");
+}
+
 - (void)testShortSyntaxWithHashAndAlpha {
     
     UIColor *whiteColorAlpha = [UIColor colorWithWhite:1 alpha:0.533333];
     UIColor *whiteHexColorAlpha = [UIColor hx_colorWithHexString:@"8fff"];
+    
+    NSAssert(whiteColorAlpha != whiteHexColorAlpha, @"hexColor is not equal to white alpha hexColor");
+}
+
+- (void)testShortRGBASyntaxWithHashAndAlpha {
+    
+    UIColor *whiteColorAlpha = [UIColor colorWithWhite:1 alpha:0.533333];
+    UIColor *whiteHexColorAlpha = [UIColor hx_colorWithHexRGBAString:@"8fff"];
     
     NSAssert(whiteColorAlpha != whiteHexColorAlpha, @"hexColor is not equal to white alpha hexColor");
 }


### PR DESCRIPTION
I deprecated the old hex string methods and duplicated them with an RGBA designation. I updated the method descriptions to indicate that the alpha goes in the end positions. This will avoid breaking any existing users out there that may be using the alpha in first position. Tests also updated to use the new RGBA method and pass accordingly.