### PR TITLE
Fixed hex variable bugs

### DIFF
--- a/HexColors-iOSTests/HexColors_iOSTests.swift
+++ b/HexColors-iOSTests/HexColors_iOSTests.swift
@@ -128,16 +128,34 @@ class HexColors_iOSTests: XCTestCase {
   }
   
   func testCanTransformToColorAndBackToHexString() {
-    let hexString = "#ff00ff"
-    let color = UIColor(hexString)
-    
-    XCTAssertEqual(hexString, color?.hex)
+    let hexStrings = [
+        "#ff0000",
+        "#00ff12",
+        "#12aaff",
+        "#00cc99",
+        "#44aadd",
+        "#dd12ff"
+    ]
+
+    for string in hexStrings {
+        let color = UIColor(string)
+        XCTAssertEqual(string, color?.hex)
+    }
   }
   
   func testCanTransformToColorWithAlphaAndBackToHexString() {
-    let hexString = "#ff00ff00"
-    let color = UIColor(hexString)
-    
-    XCTAssertEqual(hexString, color?.hex)
+    let hexStrings = [
+        "#ff000012",
+        "#00ff1234",
+        "#12aaff56",
+        "#00cc9978",
+        "#44aadd90",
+        "#dd12ffab"
+    ]
+
+    for string in hexStrings {
+        let color = UIColor(string)
+        XCTAssertEqual(string, color?.hex)
+    }
   }
 }

--- a/Sources/HexColors.swift
+++ b/Sources/HexColors.swift
@@ -42,12 +42,12 @@ public extension HexColor {
     getRed(&r, green: &g, blue: &b, alpha: &a)
     
     if a == 1 { // no alpha value set, we are returning the short version
-      rgb = (Int)(r*255)<<16 | (Int)(g*255)<<8 | (Int)(r*255)<<0
+      rgb = (Int)(r*255)<<16 | (Int)(g*255)<<8 | (Int)(b*255)<<0
+      return String(format: "#%06x", rgb)
     } else {
-      rgb = (Int)(r*255)<<24 | (Int)(g*255)<<16 | (Int)(r*255)<<8 | (Int)(a*255)<<0
+      rgb = (Int)(r*255)<<24 | (Int)(g*255)<<16 | (Int)(b*255)<<8 | (Int)(a*255)<<0
+      return String(format: "#%08x", rgb)
     }
-    
-    return String(format: "#%06x", rgb)
   }
   
   private enum `Type` {


### PR DESCRIPTION
Hex variable was returning wrong hex color values. 

First error was a typo where `r` byte istead of `b` byte. 
Second error was about string formatter where color with `alpha != 1` returning a six byte hex color value. 

Also improved tests.