### PR TITLE
Modify string character counting to Swift 4

### DIFF
--- a/Sources/HexColors.swift
+++ b/Sources/HexColors.swift
@@ -71,7 +71,7 @@ public extension HexColor {
     }
     
     static func transform(hex string: Hex) -> Type? {
-      switch string.characters.count {
+      switch string.count {
       case 3:
         return .RGBshort(rgb: string)
       case 4:


### PR DESCRIPTION
Addresses #47. Removes warning:
```'characters' is deprecated: Please use String or Substring``` 
