### PR TITLE
Update Package.swift to a functional state

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,18 +1,4 @@
-//
-//  HexColors.swift
-//
-//  Created by Marius Landwehr on 28.12.16.
-//  The MIT License (MIT)
-//  Copyright (c) 2016 Marius Landwehr marius.landwehr@gmail.com
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-// swift-tools-version:5.1
-
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
@@ -39,6 +25,8 @@ let package = Package(
     targets: [
         .target(
             name: "HexColors",
-            dependencies: [])
+            dependencies: [],
+            path: "Sources"
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,10 +10,35 @@
 //  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
+
+// swift-tools-version:5.1
 
 import PackageDescription
 
 let package = Package(
-    name: "HexColors"
+    name: "HexColors",
+    platforms: [
+        .iOS(.v11),
+        .macOS(.v10_15),
+        .tvOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "HexColors",
+            targets: ["HexColors"]),
+        .library(
+            name: "HexColors-Static",
+            type: .static,
+            targets: ["HexColors"]),
+        .library(
+            name: "HexColors-Dynamic",
+            type: .dynamic,
+            targets: ["HexColors"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "HexColors",
+            dependencies: [])
+    ]
 )


### PR DESCRIPTION
The current SPM implementation had a missing field (swift-tools-version). This made it unable to add successfully in XCode.

I also added some base package info and target to make it up to standard.